### PR TITLE
Added require 'date' to info.rb

### DIFF
--- a/lib/pdf/info.rb
+++ b/lib/pdf/info.rb
@@ -1,3 +1,4 @@
+require 'date'
 require 'pdf/info/exceptions'
 
 module PDF


### PR DESCRIPTION
DateTime is used in info.rb within, but not require 'date'.

When used in standalone pdf_info, then NameError of uninitialized constant DateTime.
