### PR TITLE
Use real exitstatus of command

### DIFF
--- a/lib/pdf/info.rb
+++ b/lib/pdf/info.rb
@@ -19,7 +19,7 @@ module PDF
 
     def command
       output = `#{self.class.command_path} -enc UTF-8 "#{@pdf_path}" -f 1 -l -1 2> /dev/null`
-      exit_code = $?
+      exit_code = $?.exitstatus
       case exit_code
       when 0 || nil
         if !output.valid_encoding?


### PR DESCRIPTION
The variable `$?` contains a `Process::Status` object (f.e. #<Process::Status: pid 45508 exit 0>). To extract the exitstatus, we need to call `exitstatus`. With this change the correct exceptions will also be thrown if f.e. the path to the file is incorrect.