### PR TITLE
For PDFs including more information per key/value pair

### DIFF
--- a/lib/pdf/info.rb
+++ b/lib/pdf/info.rb
@@ -64,11 +64,11 @@ module PDF
         when "Pages"
           metadata[:page_count] = pair.last.to_i
         when "Encrypted"
-          metadata[:encrypted] = pair.last == 'yes'
+          metadata[:encrypted] = pair.last.start_with?('yes')
         when "Optimized"
-          metadata[:optimized] = pair.last == 'yes'
+          metadata[:optimized] = pair.last.start_with?('yes')
         when "Tagged"
-          metadata[:tagged] = pair.last == 'yes'
+          metadata[:tagged] = pair.last.start_with?('yes')
         when "PDF version"
           metadata[:version] = pair.last.to_f
         when "CreationDate"


### PR DESCRIPTION
I was processing a PDF with the following line: `Encrypted: yes (print:yes copy:yes change:no addNotes:no algorithm:AES)`. The library would return `false` for `metadata[:encrypted]` - which is obviously incorrect. This PR focuses on the with characters to detect the "yes".

Would be great if you could merge this and release a new version, since this is an incorrect behavior.

Thanks for your time and effort you put into this project!