### PR TITLE
Fix CVE-2022-36231 by adding a whitelist regex

### DIFF
--- a/pdf/info.rb
+++ b/pdf/info.rb
@@ -14,7 +14,12 @@ module PDF
     end
 
     def initialize(pdf_path)
-      @pdf_path = pdf_path
+      if pdf_path.match(/[^a-z^A-Z^0-9\^_^.^-^\/]+/)
+        print "Your file name must only contain letters, digits and - _ / .\n"
+        raise exit_error
+      else
+        @pdf_path = pdf_path
+      end
     end
 
     def command


### PR DESCRIPTION
Hi !

As you can see, there is a vulnerability on your gem leading to a command injection : [https://github.com/affix/CVE-2022-36231](https://github.com/affix/CVE-2022-36231)

I've written a fix for this by adding a whitelist to only allow some characters in the name of the pdf to avoid having this vulnerability.

Regards,
Aituglo