### PR TITLE
bump version to 0.5.4 in lib

### DIFF
--- a/lib/pdf/info/version.rb
+++ b/lib/pdf/info/version.rb
@@ -1,5 +1,5 @@
 module PDF
   class Info
-    VERSION = "0.5.3"
+    VERSION = "0.5.4"
   end
 end


### PR DESCRIPTION
Hi, the version was bumped only in one `version.rb` file. This results in a wrong version for me:
```
Using pdf_info 0.5.3 from https://github.com/newspaperclub/pdf_info.git (at v0.5.4@3b30e91)
```